### PR TITLE
Don't close resp.Body() when the http client errs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -70,7 +70,6 @@ func (a *API) SourceDataQuery(ctx context.Context, st time.Time, et time.Time) (
 	req.Header.Add("Accept", "application/x-ndjson, application/ndjson")
 	resp, err := a.client.Do(req)
 	if err != nil {
-		resp.Body.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
When the http client returns an error, the response body will be nil, and closing it will panic.