### PR TITLE
validate records are json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 
 require (
 	github.com/BurntSushi/toml v1.0.0 // indirect
+	github.com/valyala/fastjson v1.6.3
 	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v1.0.0 h1:dtDWrepsVPfW9H/4y7dDgFc2MBUSeJhlaDtK13CxFlU
 github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
+github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 golang.org/x/crypto v0.0.0-20220321153916-2c7772ba3064 h1:S25/rfnfsMVgORT4/J61MJ7rdyseOZOyvLIrZEZ7s6s=
 golang.org/x/crypto v0.0.0-20220321153916-2c7772ba3064/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=

--- a/spyderbat-event-forwarder/forwarder.go
+++ b/spyderbat-event-forwarder/forwarder.go
@@ -25,6 +25,7 @@ import (
 	"spyderbat-event-forwarder/record"
 
 	"github.com/golang/groupcache/lru"
+	"github.com/valyala/fastjson"
 	"golang.org/x/crypto/blake2b"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
@@ -110,6 +111,7 @@ func printVersion() {
 
 func main() {
 
+	log.SetFlags(0)
 	configPath := flag.String("c", "config.yaml", "path to config file")
 	flag.Parse()
 
@@ -217,7 +219,15 @@ func main() {
 				lastTime = last.Time
 			}
 
-			eventLog.Print(string(record))
+			r := string(record)
+
+			// Results should always be JSON. Log non-JSON records separately.
+			err = fastjson.Validate(r)
+			if err == nil {
+				eventLog.Print(r)
+			} else {
+				log.Printf("invalid record: %s", r)
+			}
 		}
 		r.Close()
 		if err := scanner.Err(); err != nil {


### PR DESCRIPTION
The backend API should only return json, but on occasion, some non-json records have been observed. To ensure parsers only get json, perform validation on each record and send invalid records to journalctl instead.

While here, disable redundant timestamps in the journalctl log.