### PR TITLE
Support spydertraces with configurable datatypes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -95,8 +95,8 @@ func (a *API) SourceQuery(ctx context.Context) (io.ReadCloser, error) {
 }
 
 // SourceDataQuery queries the API for events within a time range
-func (a *API) SourceDataQuery(ctx context.Context, st time.Time, et time.Time) (io.ReadCloser, error) {
-	url := fmt.Sprintf("https://%s%s%s/data?dt=redflags&st=%d&et=%d", a.config.APIHost, urlBase, a.config.OrgUID, st.Unix(), et.Unix())
+func (a *API) SourceDataQuery(ctx context.Context, dataType string, st, et time.Time) (io.ReadCloser, error) {
+	url := fmt.Sprintf("https://%s%s%s/data?dt=%s&st=%d&et=%d", a.config.APIHost, urlBase, a.config.OrgUID, dataType, st.Unix(), et.Unix())
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/api/source.go
+++ b/api/source.go
@@ -9,10 +9,11 @@ import (
 )
 
 type RuntimeDetails struct {
-	CloudInstanceID string   `json:"cloud_instance_id,omitempty"`
-	IPAddresses     []string `json:"ip_addresses"`
-	MACAddresses    []string `json:"mac_addresses"`
-	Hostname        string   `json:"hostname"`
+	CloudInstanceID  string   `json:"cloud_instance_id,omitempty"`
+	IPAddresses      []string `json:"ip_addresses"`
+	MACAddresses     []string `json:"mac_addresses"`
+	Hostname         string   `json:"hostname"`
+	ForwarderVersion string   `json:"forwarder_version"`
 }
 
 type Source struct {
@@ -22,7 +23,8 @@ type Source struct {
 
 // AugmentRuntimeDetailsJSON takes JSON input, extracts the muid if there is one,
 // and augments the JSON with runtime_details from the source, if available.
-func (a *API) AugmentRuntimeDetailsJSON(record *[]byte) {
+// It also adds the version of the forwarder to the JSON.
+func (a *API) AugmentRuntimeDetailsJSON(record *[]byte, version string) {
 	if record == nil || len(*record) < 2 {
 		return
 	}
@@ -36,6 +38,7 @@ func (a *API) AugmentRuntimeDetailsJSON(record *[]byte) {
 	if !found {
 		return
 	}
+	details.ForwarderVersion = version
 
 	d, err := json.Marshal(details)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )
@@ -14,11 +16,13 @@ const (
 )
 
 type Config struct {
-	APIHost               string `yaml:"api_host"`
-	LogPath               string `yaml:"log_path"`
-	OrgUID                string `yaml:"spyderbat_org_uid"`
-	APIKey                string `yaml:"spyderbat_secret_api_key"`
-	LocalSyslogForwarding bool   `yaml:"local_syslog_forwarding"`
+	APIHost               string   `yaml:"api_host"`
+	LogPath               string   `yaml:"log_path"`
+	OrgUID                string   `yaml:"spyderbat_org_uid"`
+	APIKey                string   `yaml:"spyderbat_secret_api_key"`
+	LocalSyslogForwarding bool     `yaml:"local_syslog_forwarding"`
+	DataTypes             string   `yaml:"data_types"`
+	dataTypes             []string `yaml:"-"` // parsed data types from DataTypes, loaded on validation
 }
 
 // configItem validation
@@ -27,7 +31,7 @@ type configItem struct {
 	Key       string                    // Config key name, should match struct tag
 	Default   string                    // Default value if one is not provided
 	Required  bool                      // Die if value is not provided? (No default will be used)
-	Validator func(c *configItem) error // If set, validate further
+	Validator func(i *configItem) error // If set, validate further
 }
 
 // ensure the log path is a valid, writeable directory
@@ -46,6 +50,43 @@ func validateLogPath(c *configItem) error {
 	return os.Remove(f.Name())
 }
 
+// return comma-separated, de-duplicated values as a slice
+func getCommaSeparatedValues(c *configItem) []string {
+	dupMap := make(map[string]struct{})
+	types := strings.Split(*c.Value, ",")
+	for _, k := range types {
+		dupMap[k] = struct{}{}
+	}
+	types = make([]string, 0, len(dupMap))
+	for k := range dupMap {
+		types = append(types, k)
+	}
+	sort.Strings(types)
+	return types
+}
+
+// ensure the data types are valid
+func (c *Config) validateDataTypes(i *configItem) error {
+	validDataTypes := map[string]struct{}{
+		"redflags":     {},
+		"spydertraces": {},
+	}
+
+	types := getCommaSeparatedValues(i)
+	if len(types) == 0 {
+		return fmt.Errorf("no data types provided")
+	}
+
+	for _, t := range types {
+		if _, ok := validDataTypes[t]; !ok {
+			return fmt.Errorf("invalid data type %s", t)
+		}
+	}
+
+	c.dataTypes = types
+	return nil
+}
+
 // LoadConfig loads and parses a yaml config
 func LoadConfig(filename string) (*Config, error) {
 	log.Printf("loading config from %s", filename)
@@ -62,6 +103,12 @@ func LoadConfig(filename string) (*Config, error) {
 			Key:       "log_path",
 			Default:   defaultLogPath,
 			Validator: validateLogPath,
+		},
+		{
+			Value:     &c.DataTypes,
+			Key:       "data_types",
+			Default:   "redflags",
+			Validator: c.validateDataTypes,
 		},
 		{
 			Value:    &c.OrgUID,
@@ -101,4 +148,8 @@ func LoadConfig(filename string) (*Config, error) {
 	}
 
 	return c, nil
+}
+
+func (c *Config) GetDataTypes() []string {
+	return c.dataTypes
 }

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -10,6 +10,11 @@ api_host:
 # specify the location to write logs and keep state
 log_path: /opt/spyderbat-events/var/log
 
+# specify data types to collect
+# valid values are: redflags, spydergraphs
+# the default is: redflags
+data_types: redflags
+
 # optionally enable forwarding to the host's syslog daemon for forwarding or collection by other agents
 # NOTE: This is not recommended if syslog messages are forwarded over unencrypted channels to other hosts.
 # NOTE: This is not required for Splunk integration.


### PR DESCRIPTION
By default, only redflags will be forwarded, as before. Additional stream types can be supported by the config. Currently only redflags and spydertraces are supported.

While here, add forwarder_version with the short git hash of the forwarder to logs to make support simplier in the future.