### PR TITLE
work around buildx issues on arm64->amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,12 @@
 # syntax=docker/dockerfile:1
 
-## Build (golang v1.22)
-FROM golang@sha256:ef61a20960397f4d44b0e729298bf02327ca94f1519239ddc6d91689615b1367 AS build
-
-
-# This cannot be in /usr/local/go or the vcs embedding breaks
-WORKDIR /tmp/event-forwarder
-
-COPY ./ ./
-RUN go build -trimpath -ldflags "-s -w" -o /event-forwarder ./spyderbat-event-forwarder
-
 ## Deploy debian:stable-slim
 FROM debian@sha256:4255c9f8a4d6e66488adc0c2084c99df44bda22849b21b3afc0e9746e9a0be18
+RUN DEBIAN_FRONTEND="noninteractive" apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates
 
 WORKDIR /opt/local/spyderbat
 
-COPY --from=build /event-forwarder event-forwarder
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY ./event-forwarder event-forwarder
 COPY ./example_config.yaml config.yaml
 
 RUN adduser spyderbat

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,21 @@ VER=$(shell git describe --tags --long --always)
 BINS=spyderbat-event-forwarder.x86_64 spyderbat-event-forwarder.aarch64
 FILES=$(BINS) example_config.yaml spyderbat-event-forwarder.service install.sh README.md
 
+.PHONY: help tests release deploy clean builder updatecontainer prune
+
 help:
 	@echo please visit README.md
 
 tests:
 	go test -cover ./...
 
-release: clean tests
+spyderbat-event-forwarder.x86_64:
 	GOARCH=amd64 go build $(FLAGS) -o spyderbat-event-forwarder.x86_64 ./spyderbat-event-forwarder
+
+spyderbat-event-forwarder.aarch64:
 	GOARCH=arm64 go build $(FLAGS) -o spyderbat-event-forwarder.aarch64 ./spyderbat-event-forwarder
+
+release: clean tests spyderbat-event-forwarder.x86_64 spyderbat-event-forwarder.aarch64
 	tar cfz spyderbat-event-forwarder.$(VER).tgz $(FILES)
 	@echo '>>>' spyderbat-event-forwarder.$(VER).tgz
 
@@ -21,9 +27,33 @@ deploy: release
 	sudo journalctl -fu spyderbat-event-forwarder.service
 
 clean:
-	rm -f $(BINS) *.tgz
+	rm -f $(BINS) *.tgz container-amd64 container-arm64
 
-updatecontainer:
+builder:
+	@if ! docker buildx ls | grep -q mybuilder; then \
+		docker buildx create --name mybuilder --use; \
+	else \
+		docker buildx use mybuilder; \
+	fi
 	aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/a6j2k0g1
-	docker buildx build --platform=linux/amd64,linux/arm64 --push -t public.ecr.aws/a6j2k0g1/event-forwarder:latest .
 
+container-arm64: Dockerfile builder $(BINS)
+	cp spyderbat-event-forwarder.aarch64 event-forwarder
+	docker buildx build --platform=linux/arm64 --provenance=false --push -t public.ecr.aws/a6j2k0g1/event-forwarder:latest-arm64 .
+	rm -f event-forwarder
+	touch container-arm64
+
+container-amd64: Dockerfile builder $(BINS)
+	cp spyderbat-event-forwarder.x86_64 event-forwarder
+	docker buildx build --platform=linux/amd64 --provenance=false --push -t public.ecr.aws/a6j2k0g1/event-forwarder:latest-amd64 .
+	rm -f event-forwarder
+	touch container-amd64
+
+updatecontainer: container-arm64 container-amd64
+	-docker manifest rm public.ecr.aws/a6j2k0g1/event-forwarder:latest
+	docker manifest create public.ecr.aws/a6j2k0g1/event-forwarder:latest \
+		--amend public.ecr.aws/a6j2k0g1/event-forwarder:latest-amd64 \
+		--amend public.ecr.aws/a6j2k0g1/event-forwarder:latest-arm64
+
+prune:
+	docker buildx prune -f


### PR DESCRIPTION
For some reason, the amd64-native Go compiler likes to crash when running under QEMU or Rosetta 2 on an arm64 system. Instead, leverage Go's cross-compiler on the native arch, and assemble the manifest separately. This also speeds up container builds significantly.